### PR TITLE
v0.4

### DIFF
--- a/Assets/Merino/Editor/MerinoEditorWindow.cs
+++ b/Assets/Merino/Editor/MerinoEditorWindow.cs
@@ -761,7 +761,7 @@ namespace Merino
                 } else if(step is Yarn.Dialogue.NodeCompleteResult) {
 
                     // Wait for post-node action
-                    var nodeResult = step as Yarn.Dialogue.NodeCompleteResult;
+                    // var nodeResult = step as Yarn.Dialogue.NodeCompleteResult;
                     // yield return this.StartCoroutine (this.dialogueUI.NodeComplete (nodeResult.nextNode));
                 }
             }
@@ -934,10 +934,10 @@ namespace Merino
 			if (EditorGUI.EndChangeCheck())
 			{
 //				Undo.RecordObject(treeData, "Merino: add new node");
-//				if (addNewNode)
-//				{
+				if (addNewNode)
+				{
 					AddNewNode();
-//				}
+				}
 			}
 			rect.y += BUTTON_HEIGHT;
 			rect.height -= BUTTON_HEIGHT;

--- a/Assets/Merino/Editor/MerinoTreeElement.cs
+++ b/Assets/Merino/Editor/MerinoTreeElement.cs
@@ -10,7 +10,7 @@ namespace Merino
 	{
 	//	public float floatValue1, floatValue2, floatValue3;
 	//	public Material material;
-		public Color nodeColor;
+	//	public Color nodeColor;
 		public Vector2Int nodePosition;
 		//public string nodeTitle = "";
 		public string nodeTags = "";

--- a/Assets/Merino/Editor/YarnSpinnerConsole/YarnSpinnerFileFormatConverter.cs
+++ b/Assets/Merino/Editor/YarnSpinnerConsole/YarnSpinnerFileFormatConverter.cs
@@ -218,7 +218,7 @@ namespace Yarn
 
 		public static void ConvertNodesInFile(ConvertFormatOptions options, string file, string fileExtension, ConvertNodesToText convert)
 		{
-			var d = new Dialogue(null);
+		//	var d = new Dialogue(null);
 
 			var text = File.ReadAllText(file);
 

--- a/Assets/Merino/Editor/YarnSpinnerConsole/YarnSpinnerLoader.cs
+++ b/Assets/Merino/Editor/YarnSpinnerConsole/YarnSpinnerLoader.cs
@@ -46,17 +46,17 @@ using System.Linq;
 
 namespace Yarn {
 
-	public enum NodeFormat
-	{
-		Unknown, // an unknown type
-
-		SingleNodeText, // a plain text file containing a single node with no metadata
-
-		JSON, // a JSON file containing multiple nodes with metadata
-
-		Text, //  a text file containing multiple nodes with metadata
-
-	}
+//	public enum NodeFormat
+//	{
+//		Unknown, // an unknown type
+//
+//		SingleNodeText, // a plain text file containing a single node with no metadata
+//
+//		JSON, // a JSON file containing multiple nodes with metadata
+//
+//		Text, //  a text file containing multiple nodes with metadata
+//
+//	}
 
 	public class YarnSpinnerLoader {
 

--- a/Assets/Merino/Editor/YarnSpinnerConsole/YarnSpinnerLoader.cs
+++ b/Assets/Merino/Editor/YarnSpinnerConsole/YarnSpinnerLoader.cs
@@ -392,6 +392,9 @@ namespace Yarn {
 					return new List<string>(tags.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries));
 				}
 			}
+			
+			// 5 September 2018 -- this is just for Merino
+			public string parent { get; set; }
 
 		}
 


### PR DESCRIPTION
- yarn compile errors now caught and visualized in the Merino node edit pane
- when clicking "view node source" button when playtesting, Merino now does its best to scroll to that line in the script (but if it can't match that line text exactly, the scroll will fail)
- added node hierarchy / parenting support (can save and load)... NOTE: this is, for now, a Merino-only feature, and is unsupported / probably stripped out if you try to save the same file in another Yarn editor... see issue #3 
- misc UI tweaks (added bottom status bar with "playtest last edited node" button)