### PR TITLE
hotfixes for #16 and #21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ Assets/Plugins/Editor/JetBrains*
 
 #Merino stuff
 /Assets/Merino/Editor/MerinoTempData*
+Logs/

--- a/Assets/Merino/Editor/Scripts/BackendData/MerinoTreeData.cs
+++ b/Assets/Merino/Editor/Scripts/BackendData/MerinoTreeData.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor.TreeViewExamples;
+using UnityEditor.IMGUI.Controls;
 
 namespace Merino
 {
@@ -10,6 +11,9 @@ namespace Merino
 		public int editedID = -1;
 		public double timestamp;
 		[SerializeField] List<MerinoTreeElement> m_TreeElements = new List<MerinoTreeElement> ();
+		[SerializeField] public List<TextAsset> currentFiles = new List<TextAsset>();
+		[SerializeField] public Dictionary<TextAsset, int> fileToNodeID = new Dictionary<TextAsset, int>();
+		[SerializeField] public TreeViewState viewState = new TreeViewState();
 
 		internal List<MerinoTreeElement> treeElements
 		{

--- a/Assets/Merino/Editor/Scripts/MerinoPrefs.cs
+++ b/Assets/Merino/Editor/Scripts/MerinoPrefs.cs
@@ -14,6 +14,7 @@ namespace Merino
 		public static Color highlightShortcutOptions = new Color(0.2f, 0.6f, 0.7f);
 		// public static Color highlightVariables;
 		public static bool useYarnSpinnerExperimentalMode = false;
+		public static bool validateNodeTitles = true;
 
 		//hidden prefs
 		public static bool stopOnDialogueEnd = true;
@@ -54,6 +55,9 @@ namespace Merino
 			// 14 Oct 2018: commented out experimental mode, it seems to have the same parser problem as before: can't read "---" sentinel, keeps looking for node header data  -RY
 			// useYarnSpinnerExperimentalMode = EditorGUILayout.ToggleLeft("Use Yarn Spinner's experimental ANTLR parser", useYarnSpinnerExperimentalMode);
 
+			// 23 Jan 2019: in reponse to GitHub issue #16, let user disable node validation? (even though I don't really see the point...)
+			validateNodeTitles = EditorGUILayout.ToggleLeft("Validate and correct duplicate node titles", validateNodeTitles);
+
 			GUILayout.Label("Syntax Highlighting Colors", EditorStyles.boldLabel);
 			highlightCommands = EditorGUILayout.ColorField("<<Commands>>", highlightCommands);
 			highlightComments = EditorGUILayout.ColorField("// Comments", highlightComments);
@@ -87,6 +91,7 @@ namespace Merino
 		{
 			newFileTemplatePath = "NewFileTemplate.yarn";
 			useYarnSpinnerExperimentalMode = false;
+			validateNodeTitles = true;
 			
 			highlightComments = new Color(0.3f, 0.6f, 0.25f);
 			highlightCommands = new Color(0.8f, 0.5f, 0.1f);
@@ -119,6 +124,7 @@ namespace Merino
 			}
 			newFileTemplatePath = EditorPrefs.GetString("MerinoTemplatePath", newFileTemplatePath);
 			useYarnSpinnerExperimentalMode = EditorPrefs.GetBool("MerinoExperimentalMode", useYarnSpinnerExperimentalMode);
+			validateNodeTitles = EditorPrefs.GetBool("MerinoValidateNodeTitles", validateNodeTitles );
 
 			ColorUtility.TryParseHtmlString(EditorPrefs.GetString("MerinoHighlightCommands"), out highlightCommands);
 			ColorUtility.TryParseHtmlString(EditorPrefs.GetString("MerinoHighlightComments"), out highlightComments);
@@ -146,6 +152,7 @@ namespace Merino
 		{
 			EditorPrefs.SetString("MerinoTemplatePath", newFileTemplatePath);
 			EditorPrefs.SetBool("MerinoExperimentalMode", useYarnSpinnerExperimentalMode);
+			EditorPrefs.SetBool("MerinoValidateNodeTitles", validateNodeTitles );
 			
 			EditorPrefs.SetString("MerinoHighlightCommands", "#"+ColorUtility.ToHtmlStringRGB(highlightCommands) );
 			EditorPrefs.SetString("MerinoHighlightComments", "#"+ColorUtility.ToHtmlStringRGB(highlightComments) );

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
-    "com.unity.package-manager-ui": "1.9.11",
-    "com.unity.textmeshpro": "1.2.4",
+    "com.unity.collab-proxy": "1.2.15",
+    "com.unity.package-manager-ui": "2.0.3",
+    "com.unity.textmeshpro": "1.3.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.2.4f1
+m_EditorVersion: 2018.3.2f1

--- a/ProjectSettings/VFXManager.asset
+++ b/ProjectSettings/VFXManager.asset
@@ -1,0 +1,11 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!937362698 &1
+VFXManager:
+  m_ObjectHideFlags: 0
+  m_IndirectShader: {fileID: 0}
+  m_CopyBufferShader: {fileID: 0}
+  m_SortShader: {fileID: 0}
+  m_RenderPipeSettingsPath: 
+  m_FixedTimeStep: 0.016666668
+  m_MaxDeltaTime: 0.05


### PR DESCRIPTION
I know nodemap stuff is still in progress / a big architecture change… and also implements some of this stuff, so just ignore this when merging later on ok?...

fix for issues #21, possible workaround for #16
- updated to Unity 2018.3.2f1, added \Logs\ to .gitignore
- attempt to fix issue #21 with (1) moving currentFiles and fileNodeToID to the scriptable object (so that it survives assembly AND window reloads)... (2) tries to fetch scriptable object via instance ID too, which maybe works sometimes?