### PR TITLE
v0.5.4, bug fixes and maintenance

### DIFF
--- a/Assets/Merino/Editor/Scripts/MerinoEditorResources.cs
+++ b/Assets/Merino/Editor/Scripts/MerinoEditorResources.cs
@@ -164,6 +164,10 @@ namespace Merino
                         else
                         {
                             prop.FindPropertyRelative("free").objectReferenceValue = texture;
+                            // if there isn't a pro version, then just use the free version
+                            if ( prop.FindPropertyRelative("pro").objectReferenceValue == null ) {
+                                prop.FindPropertyRelative("pro").objectReferenceValue = texture;
+                            }
                         }
                     }       
                 }

--- a/Assets/Merino/Editor/Scripts/MerinoStyles.cs
+++ b/Assets/Merino/Editor/Scripts/MerinoStyles.cs
@@ -13,7 +13,7 @@ namespace Merino
 			{
 				if (_monoFont == null)
 				{
-					_monoFont = AssetDatabase.LoadAssetAtPath<Font>("Assets/Merino/Editor/Fonts/Inconsolata-Regular.ttf");
+					_monoFont = AssetDatabase.LoadAssetAtPath<Font>(MerinoCore.LocateMerinoFolder( relativeToProjectFolder:true ) + "/Editor/Fonts/Inconsolata-Regular.ttf");
 				}
 
 				return _monoFont;

--- a/Assets/Merino/Editor/Scripts/MerinoTreeElement.cs
+++ b/Assets/Merino/Editor/Scripts/MerinoTreeElement.cs
@@ -17,9 +17,11 @@ namespace Merino
 		public string nodeBody = "";
 		public LeafType leafType; // needed for file / folder support in Merino's hierarchy view
 		public Vector2Int nodePosition;
+		public int cachedParentID = -1; // needed for easier searching
 
 		public MerinoTreeElement (string name, int depth, int id) : base (name, depth, id)
 		{
+			
 		}
 	}
 }

--- a/Assets/Merino/Editor/Scripts/MerinoTreeView.cs
+++ b/Assets/Merino/Editor/Scripts/MerinoTreeView.cs
@@ -18,7 +18,8 @@ namespace Merino
 		// corresponds to MerinoTreeElement.leafType
 		static Texture2D[] MerinoIcons =
 		{
-			(Texture2D)Resources.Load<Texture>("Merino_NodeIcon"),
+			//(Texture2D)Resources.Load<Texture>("Merino_NodeIcon"),
+			MerinoEditorResources.Node,
 			(Texture2D)EditorGUIUtility.IconContent ("TextAsset Icon").image, // FILE
 			EditorGUIUtility.FindTexture ("Folder Icon") // FOLDER
 		};

--- a/Assets/Merino/Editor/Scripts/PluginUpdateCheck.cs
+++ b/Assets/Merino/Editor/Scripts/PluginUpdateCheck.cs
@@ -30,7 +30,7 @@ namespace Merino
         /// <summary>
         /// Version of the plugin, this will be compared against the latest release on GitHub.
         /// </summary>
-        private static readonly Version CurrentVersion = new Version("0.5.2");
+        private static readonly Version CurrentVersion = new Version("0.5.4");
         /// <summary>
         /// Github user/organization the repo belongs to.
         /// </summary>
@@ -180,7 +180,7 @@ namespace Merino
             Close();
         }
         
-        [MenuItem("Tools/" + pluginName + "/Check for Updates")]
+        [MenuItem(pluginName + "/Check for Updates")]
         private static void CheckForUpdates()
         {
             forceCheckVersion = true;

--- a/Assets/Merino/EditorResources/MerinoEditorResources.asset
+++ b/Assets/Merino/EditorResources/MerinoEditorResources.asset
@@ -15,22 +15,22 @@ MonoBehaviour:
   updateOnReloadScripts: 0
   node:
     free: {fileID: 2800000, guid: cfaaccf24fdb57447bcc7ce7dc217378, type: 3}
-    pro: {fileID: 0}
+    pro: {fileID: 2800000, guid: cfaaccf24fdb57447bcc7ce7dc217378, type: 3}
   node_add:
     free: {fileID: 2800000, guid: 1db30a65c5e27b3418682f9a0ecc986c, type: 3}
-    pro: {fileID: 0}
+    pro: {fileID: 2800000, guid: 1db30a65c5e27b3418682f9a0ecc986c, type: 3}
   node_delete:
     free: {fileID: 2800000, guid: e6afef112bd76124abc0b7b1965b6a6f, type: 3}
-    pro: {fileID: 0}
+    pro: {fileID: 2800000, guid: e6afef112bd76124abc0b7b1965b6a6f, type: 3}
   node_edit:
     free: {fileID: 2800000, guid: 1e7568c926ac7b54089818d6fffb17b7, type: 3}
-    pro: {fileID: 0}
+    pro: {fileID: 2800000, guid: 1e7568c926ac7b54089818d6fffb17b7, type: 3}
   page:
     free: {fileID: 2800000, guid: 75b00a6c479ed42488cafaf0b517fd85, type: 3}
-    pro: {fileID: 0}
+    pro: {fileID: 2800000, guid: 75b00a6c479ed42488cafaf0b517fd85, type: 3}
   page_new:
     free: {fileID: 2800000, guid: 5b2c387a7ea222d4dad0d09a672c870d, type: 3}
-    pro: {fileID: 0}
+    pro: {fileID: 2800000, guid: 5b2c387a7ea222d4dad0d09a672c870d, type: 3}
   save:
     free: {fileID: 2800000, guid: 08e96a7a017ea0c4aa5606e05a552a73, type: 3}
     pro: {fileID: 2800000, guid: 8ae809f37db00cc41bded85e1939f7a9, type: 3}

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.package-manager-ui": "2.1.2",
-    "com.unity.textmeshpro": "2.0.0",
+    "com.unity.textmeshpro": "2.0.1",
     "com.unity.timeline": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.1.0f2
-m_EditorVersionWithRevision: 2019.1.0f2 (292b93d75a2c)
+m_EditorVersion: 2019.1.8f1
+m_EditorVersionWithRevision: 2019.1.8f1 (7938dd008a75)

--- a/ProjectSettings/XRSettings.asset
+++ b/ProjectSettings/XRSettings.asset
@@ -1,0 +1,10 @@
+{
+    "m_SettingKeys": [
+        "VR Device Disabled",
+        "VR Device User Alert"
+    ],
+    "m_SettingValues": [
+        "False",
+        "False"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -9,16 +9,18 @@ download and install from the [Releases page](https://github.com/radiatoryang/me
 - "minimal" .unitypackage is just Merino folder
 
 ## usage / help / how-to / documentation
-read the [wiki documentation](https://github.com/radiatoryang/merino/wiki) for info on writing with Yarn / troubleshooting and tech support... [changelog is here](https://github.com/radiatoryang/merino/wiki/Changelog)
+read the [wiki documentation](https://github.com/radiatoryang/merino/wiki) for info on writing with Yarn / troubleshooting and tech support... [full changelog is here](https://github.com/radiatoryang/merino/wiki/Changelog)
 
 ### roadmap
 - edit Yarn node tags
-- auto-complete typing
-- detect characters, functions, nodes, variables for auto-complete
-- inline syntax highlighting for variable names somehow
 - node map visualization
+- line tagging for localization (pending new Yarn Spinner update)
 
-### uses other peoples code
+## maintainers
+- Robert Yang @radiatoryang
+- Adrienne Lombardo @charblar
+
+### uses other peoples' code
 - Unity Editor Coroutines https://github.com/marijnz/unity-editor-coroutines
 - Yarn Spinner https://github.com/thesecretlab/YarnSpinner
 - Yarn https://github.com/InfiniteAmmoInc/Yarn


### PR DESCRIPTION
fixed issue #23 (font path in MerinoStyles.cs wasn't getting updated with folder move)
fixed issue #28 (Merino lets you delete all nodes from a file but then refuses to load an empty file)
fixed a bug with filenames on MacOS
fixed some file handling for when a file gets deleted or moved out of project folder
creating new nodes now adds the new node to your selection
fixed icons so that they work again? maybe?
updated base project to Unity 2019.1.8f1